### PR TITLE
add_proto_header

### DIFF
--- a/front/App_front/src/components/ui/sidebar/app-sidebar.tsx
+++ b/front/App_front/src/components/ui/sidebar/app-sidebar.tsx
@@ -14,27 +14,37 @@ import {
 // Menu items.
 const items = [
   {
-    title: 'Home',
+    title: 'マイページ',
     url: '#',
     icon: Home,
   },
   {
-    title: 'Inbox',
+    title: '記録する',
     url: '#',
     icon: Inbox,
   },
   {
-    title: 'Calendar',
+    title: '一覧',
     url: '#',
     icon: Calendar,
   },
   {
-    title: 'Search',
+    title: '振り返り',
     url: '#',
     icon: Search,
   },
   {
-    title: 'Settings',
+    title: 'プライバシーポリシー',
+    url: '#',
+    icon: Settings,
+  },
+  {
+    title: '利用規約',
+    url: '#',
+    icon: Settings,
+  },
+  {
+    title: 'お問い合わせ',
     url: '#',
     icon: Settings,
   },

--- a/front/App_front/src/components/ui/sidebar/sidebar.tsx
+++ b/front/App_front/src/components/ui/sidebar/sidebar.tsx
@@ -28,8 +28,8 @@ import {
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = '16rem';
-const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH = '24rem';
+const SIDEBAR_WIDTH_MOBILE = '28rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
@@ -242,7 +242,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="bg-white/30 backdrop-blur-md group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>
@@ -393,7 +393,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-lg font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className
       )}
@@ -430,7 +430,7 @@ function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'
     <div
       data-slot="sidebar-group-content"
       data-sidebar="group-content"
-      className={cn('w-full text-sm', className)}
+      className={cn('w-full text-md', className)}
       {...props}
     />
   );
@@ -468,7 +468,7 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-8 text-sm',
+        default: 'h-8 text-md',
         sm: 'h-7 text-xs',
         lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
       },


### PR DESCRIPTION
## 概要
shadcn/ui でsidebarコンポーネントをinsatall
src/components/ui　に/sidebarディレクトリを作成してsidebar用で作成したファイルを格納
開発元のsidebarの文言を流用

## 変更点
- sidebar用ディレクトリを作成
- 文字サイズや背景色を開発元から流用してデフォルトを修正


## 関連Issue

- close #50
- close #
